### PR TITLE
manifest: Build GIMP 3.0 manual

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.gimp.GIMP.Manual.json
+++ b/org.gimp.GIMP.Manual.json
@@ -1,49 +1,27 @@
 {
     "id": "org.gimp.GIMP.Manual",
-    "branch": "2.10",
+    "branch": "3.0",
     "runtime": "org.gimp.GIMP",
     "runtime-version": "stable",
-    "sdk": "org.gnome.Sdk//41",
+    "sdk": "org.gnome.Sdk//48",
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {
-        "prefix": "/app/share/gimp/2.0/help",
-        "prepend-path": "/app/share/gimp/2.0/help/bin",
-        "env": {
-            "PYTHONPATH": "/app/share/gimp/2.0/help/lib/python2.7/site-packages/"
-        }
+        "prefix": "/app/share/gimp/3.0/help",
+        "prepend-path": "/app/share/gimp/3.0/help/bin"
     },
     "cleanup": [
         "/bin",
         "/lib"
     ],
     "modules": [
-        "shared-modules/python2.7/python-2.7.json",
         {
             "name": "gimp-help",
-            "modules": [
-                {
-                    "name": "python2-libxml2",
-                    "cleanup": [
-                        "*"
-                    ],
-                    "config-opts": [
-                        "--with-python=/app/share/gimp/2.0/help"
-                    ],
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "ftp://xmlsoft.org/libxml2/libxml2-2.9.12.tar.gz",
-                            "sha256": "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
-                        }
-                    ]
-                }
-            ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gimp.org/pub/gimp/help/gimp-help-2.10.0.tar.bz2",
-                    "sha256": "03804fed071b49e5810edd8327868659dfd9932fbf34d34189d56bd0ad539118"
+                    "url": "https://download.gimp.org/pub/gimp/help/gimp-help-3.0.0.tar.bz2",
+                    "sha256": "9adf5aa0f1fa424a9cc2d3c30e40154cb37ccc2602f66c7ec7141a7b7ee87342"
                 },
                 {
                     "type": "shell",
@@ -56,6 +34,7 @@
         {
             "name": "metadata",
             "buildsystem": "simple",
+            "no-parallel-make": true,
             "build-commands": [
             ],
             "post-install": [


### PR DESCRIPTION
Does not build. 

Locally, it stops with error 15 at:

```
*** Making html for da ...
```

On CI, it stops at:

```
/usr/bin/msgfmt: error while writing "messages.mo" file: Operation not permitted
make[1]: *** [Makefile:1302: po/da/menus/filters.po] Error 70
```

On CI with `no-parallel-make`, it stops at:

```
xml/da/gimp.xml:129: element include: XInclude error : could not load xml/da/using/shortcuts.xml, and no fallback was found
make[1]: *** [Makefile:1428: html/da/index.html] Error 6
```